### PR TITLE
fix: remove uesless go routine

### DIFF
--- a/controllers/daily/grundo.go
+++ b/controllers/daily/grundo.go
@@ -10,35 +10,32 @@ import (
 func MagicBlueGrundo(w http.ResponseWriter, r *http.Request) {
 	var body types.NeopetsSession
 
-	gundoChan := make(chan string)
-	errorChan := make(chan error)
 	err := json.NewDecoder(r.Body).Decode(&body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	go services.GetMagicBlueGrundoGift(body.Session, gundoChan, errorChan)
+	gift, err := services.GetMagicBlueGrundoGift(body.Session)
 
-	select {
-	case gift := <-gundoChan:
-		value, err := json.Marshal(services.BlueGrundoGift{
-			Gift: gift,
-		})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+	value, err := json.Marshal(services.BlueGrundoGift{
+		Gift: gift,
+	})
 
-		_, err = w.Write(value)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	case err := <-errorChan:
-		http.Error(w, err.Error(), http.StatusBadRequest)
+	_, err = w.Write(value)
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/services/magic-blue-grundo.go
+++ b/services/magic-blue-grundo.go
@@ -18,7 +18,7 @@ type BlueGrundoGift struct {
 /**
 Once a day to get magic blue grundo's gift
 */
-func GetMagicBlueGrundoGift(session string, resultChan chan string, errorChan chan error) {
+func GetMagicBlueGrundoGift(session string) (string, error) {
 	res, err := common.Got("POST", GrundoGift, strings.NewReader("talkto=1"), []*http.Cookie{
 		{
 			Name:   "neologin",
@@ -27,19 +27,17 @@ func GetMagicBlueGrundoGift(session string, resultChan chan string, errorChan ch
 		},
 	})
 	if err != nil {
-		errorChan <- err
-		return
+		return "", err
 	}
 	defer res.Body.Close()
 
 	doc, err := goquery.NewDocumentFromReader(res.Body)
 	if err != nil {
-		errorChan <- err
-		return
+		return "", err
 	}
 	text := strings.TrimSpace(doc.Find("#content > table > tbody > tr > td.content > div[align=center] > b").First().Text())
 
 	log.Print("Got " + text)
 
-	resultChan <- text
+	return text, nil
 }

--- a/services/shop-of-offer.go
+++ b/services/shop-of-offer.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"log"
 	"neopets/common"
 	"net/http"
 	"regexp"
@@ -19,7 +18,7 @@ type OfferNp struct {
 /**
 Rich Slorg: Get 100 NP or 50 NP a day
 */
-func GetShopOfOffer(session string, resultChan chan string, errorChan chan error) {
+func GetShopOfOffer(session string) (string, error) {
 	res, err := common.Got("GET", ShopOfOffer, nil, []*http.Cookie{
 		{
 			Name:   "neologin",
@@ -28,19 +27,17 @@ func GetShopOfOffer(session string, resultChan chan string, errorChan chan error
 		},
 	})
 	if err != nil {
-		errorChan <- err
-		return
+		return "", err
 	}
 	defer res.Body.Close()
 
 	doc, err := goquery.NewDocumentFromReader(res.Body)
 	if err != nil {
-		errorChan <- err
-		return
+		return "", err
 	}
 	text := strings.TrimSpace(doc.Find("#content > table > tbody > tr > td.content > table > tbody").First().Text())
 	re := regexp.MustCompile(`\d+ Neopoints`)
 	np := string(re.Find([]byte(text)))
-	resultChan <- np
-	log.Print("Got " + np)
+
+	return np, nil
 }

--- a/services/trudys-surprise.go
+++ b/services/trudys-surprise.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"neopets/common"
 	"net/http"
@@ -27,7 +26,7 @@ type SurpriseItem struct {
 	Error      string          `json:"error"`
 }
 
-func GetTrudysSurprise(session string, resultChan chan SurpriseItem, errorChan chan error) {
+func GetTrudysSurprise(session string) (*SurpriseItem, error) {
 	data := url.Values{}
 	data.Set("action", TrudysSurpriseAction)
 	res, err := common.Got(http.MethodPost, TrudysSurpriseURL, strings.NewReader(data.Encode()), []*http.Cookie{
@@ -39,27 +38,23 @@ func GetTrudysSurprise(session string, resultChan chan SurpriseItem, errorChan c
 	})
 
 	if err != nil {
-		errorChan <- err
-		return
+		return nil, err
 	}
 
 	defer res.Body.Close()
 	bodyBytes, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		errorChan <- err
-		return
+		return nil, err
 	}
 
 	var item SurpriseItem
 	if err := json.Unmarshal(bodyBytes, &item); err != nil {
-		errorChan <- err
-		return
+		return nil, err
 	}
 
 	if item.Error != "" {
-		errorChan <- errors.New(item.Error)
-		return
+		return nil, err
 	}
 
-	resultChan <- item
+	return &item, nil
 }


### PR DESCRIPTION
https://golang.org/pkg/net/http/#Serve

> Serve accepts incoming HTTP connections on the listener l, creating a new service goroutine for each. The service goroutines read requests and then call handler to reply to them.

So there is no need to use go routine.

